### PR TITLE
Update createpost page to match PhotoView style

### DIFF
--- a/HungerTracker/app/(stack)/createpost.tsx
+++ b/HungerTracker/app/(stack)/createpost.tsx
@@ -1,30 +1,44 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, TouchableOpacity, Alert, Text } from 'react-native';
+import { Image } from 'expo-image';
+import { SymbolView } from 'expo-symbols';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import IconButton from '../components/IconButton';
 import GradientButton from '../components/GradientButton';
-import { colors, spacing } from '../theme';
+import { colors } from '../theme';
+import { configureReanimatedLogger, ReanimatedLogLevel } from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
+configureReanimatedLogger({
+  level: ReanimatedLogLevel.warn,
+  strict: false,
+});
 
 export default function CreatePost() {
   const { imageUri } = useLocalSearchParams<{ imageUri?: string }>();
   const router = useRouter();
 
   return (
-    <SafeAreaView style={styles.container}>
-      <IconButton
-        iosName="chevron.backward"
-        androidName="arrow-back"
-        containerStyle={styles.backButton}
-        onPress={() => router.back()}
-      />
+    <Animated.View
+      layout={LinearTransition}
+      entering={FadeIn}
+      exiting={FadeOut}
+      style={styles.container}
+    >
       {imageUri && (
-        <Image source={{ uri: imageUri }} style={styles.image} />
+        <Image source={{ uri: imageUri }} style={styles.image} contentFit="cover" />
       )}
-      <GradientButton style={styles.postButton} onPress={() => {}}>
-        <Text style={styles.postButtonText}>Post</Text>
+      <TouchableOpacity style={styles.closeButton} onPress={() => router.back()}>
+        <SymbolView
+          name="xmark.circle.fill"
+          type="hierarchical"
+          tintColor="white"
+          size={40}
+        />
+      </TouchableOpacity>
+      <GradientButton style={styles.button} onPress={() => Alert.alert('Post')}>
+        <Text style={styles.buttonText}>Post</Text>
       </GradientButton>
-    </SafeAreaView>
+    </Animated.View>
   );
 }
 
@@ -33,24 +47,26 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.bg[1],
   },
-  backButton: {
-    position: 'absolute',
-    top: spacing.xl + 25,
-    left: spacing.xl,
-    zIndex: 10,
-  },
   image: {
     flex: 1,
     width: '100%',
-    height: undefined,
+    height: '100%',
   },
-  postButton: {
+  closeButton: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    padding: 10,
+  },
+  button: {
+    position: 'absolute',
+    bottom: 16,
+    paddingHorizontal: 16,
     width: '90%',
     alignSelf: 'center',
-    marginBottom: spacing.lg,
   },
-  postButtonText: {
-    color: colors.buttonText,
+  buttonText: {
+    color: colors.text[1],
     fontSize: 16,
     fontWeight: 'bold',
   },


### PR DESCRIPTION
## Summary
- make createpost.tsx a fullscreen image view similar to `PhotoView`
- add reanimated transitions and close button

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx jest --runInBand` *(fails: requires installing jest)*

------
https://chatgpt.com/codex/tasks/task_e_6841f952654c83269759a5e3d1918b28