### PR TITLE
Add friends bottom sheet with map focus

### DIFF
--- a/HungerTracker/app/(tabs)/index.tsx
+++ b/HungerTracker/app/(tabs)/index.tsx
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.25,
     shadowRadius: 3.84,
     elevation: 5,
-    zIndex: 1001,
+    zIndex: 999,
   },
   profileButton: {
     position: "absolute",

--- a/HungerTracker/app/(tabs)/index.tsx
+++ b/HungerTracker/app/(tabs)/index.tsx
@@ -1,18 +1,40 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { View, Image, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import MapScreen from "../components/MapScreen";
+import MapScreen, { EXAMPLE_USERS, MapUser } from "../components/MapScreen";
 import { colors, spacing } from "../theme";
 import { Link } from "expo-router";
 import MotiveInvitation from "../components/MotiveInvitation";
 import { LinearGradient } from "expo-linear-gradient";
+import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import FriendsBottomSheet from "../components/FriendsBottomSheet";
+import type MapView from "react-native-maps";
 
 export default function Index() {
   const [showInvite, setShowInvite] = useState(false);
+  const [showMotiveButton, setShowMotiveButton] = useState(true);
+  const mapRef = useRef<MapView>(null);
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+  const handleFriendPress = (friend: MapUser) => {
+    bottomSheetRef.current?.dismiss();
+    mapRef.current?.animateToRegion(
+      {
+        ...friend.location,
+        latitudeDelta: 0.05,
+        longitudeDelta: 0.05,
+      },
+      500
+    );
+  };
+
+  const handleSheetChange = (index: number) => {
+    setShowMotiveButton(index < 2);
+  };
 
   return (
     <View style={styles.container}>
-      <MapScreen />
+      <MapScreen mapRef={mapRef} />
       {/* Notification Button */}
       <TouchableOpacity
         style={styles.notificationButton}
@@ -29,16 +51,23 @@ export default function Index() {
           />
         </TouchableOpacity>
       </Link>
+      {/* Friends Button */}
+      <TouchableOpacity
+        style={styles.friendsButton}
+        onPress={() => bottomSheetRef.current?.present()}
+      >
+        <Ionicons name="people" size={24} color={colors.text[1]} />
+      </TouchableOpacity>
       {/* Motive Create Button */}
-
-      <LinearGradient colors={colors.grad.p1} style={styles.motiveButton}>
-        <Link href="/(stack)/motivecreate" asChild>
-          <TouchableOpacity>
-            {/* style={styles.motiveButton}> */}
-            <Ionicons name="add" size={24} color={colors.text[1]} />
-          </TouchableOpacity>
-        </Link>
-      </LinearGradient>
+      {showMotiveButton && (
+        <LinearGradient colors={colors.grad.p1} style={styles.motiveButton}>
+          <Link href="/(stack)/motivecreate" asChild>
+            <TouchableOpacity>
+              <Ionicons name="add" size={24} color={colors.text[1]} />
+            </TouchableOpacity>
+          </Link>
+        </LinearGradient>
+      )}
 
       {/* Motive Invitation Overlay */}
       {showInvite && (
@@ -52,6 +81,13 @@ export default function Index() {
           </TouchableOpacity>
         </TouchableOpacity>
       )}
+
+      <FriendsBottomSheet
+        bottomSheetRef={bottomSheetRef}
+        friends={EXAMPLE_USERS.map((u) => ({ ...u, subtitle: 'last mucked 2hrs ago - 3.7km' }))}
+        onFriendPress={handleFriendPress}
+        onChange={handleSheetChange}
+      />
     </View>
   );
 }
@@ -124,5 +160,19 @@ const styles = StyleSheet.create({
     alignItems: "center",
     zIndex: 2000,
     backgroundColor: "rgba(0,0,0,0.15)",
+  },
+  friendsButton: {
+    position: "absolute",
+    bottom: spacing.xl,
+    left: spacing.xl,
+    backgroundColor: colors.bg[1],
+    padding: spacing.md,
+    borderRadius: 16,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
+    zIndex: 1001,
   },
 });

--- a/HungerTracker/app/(tabs)/index.tsx
+++ b/HungerTracker/app/(tabs)/index.tsx
@@ -3,10 +3,10 @@ import { View, Image, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import MapScreen, { EXAMPLE_USERS, MapUser } from "../components/MapScreen";
 import { colors, spacing } from "../theme";
-import { Link } from "expo-router";
+import { Link, router } from "expo-router";
 import MotiveInvitation from "../components/MotiveInvitation";
 import { LinearGradient } from "expo-linear-gradient";
-import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { BottomSheet } from "@gorhom/bottom-sheet";
 import FriendsBottomSheet from "../components/FriendsBottomSheet";
 import type MapView from "react-native-maps";
 
@@ -14,10 +14,10 @@ export default function Index() {
   const [showInvite, setShowInvite] = useState(false);
   const [showMotiveButton, setShowMotiveButton] = useState(true);
   const mapRef = useRef<MapView>(null);
-  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const bottomSheetRef = useRef<BottomSheet>(null);
 
   const handleFriendPress = (friend: MapUser) => {
-    bottomSheetRef.current?.dismiss();
+    bottomSheetRef.current?.snapToIndex(0);
     mapRef.current?.animateToRegion(
       {
         ...friend.location,
@@ -51,21 +51,17 @@ export default function Index() {
           />
         </TouchableOpacity>
       </Link>
-      {/* Friends Button */}
-      <TouchableOpacity
-        style={styles.friendsButton}
-        onPress={() => bottomSheetRef.current?.present()}
-      >
-        <Ionicons name="people" size={24} color={colors.text[1]} />
-      </TouchableOpacity>
       {/* Motive Create Button */}
       {showMotiveButton && (
         <LinearGradient colors={colors.grad.p1} style={styles.motiveButton}>
-          <Link href="/(stack)/motivecreate" asChild>
-            <TouchableOpacity>
-              <Ionicons name="add" size={24} color={colors.text[1]} />
-            </TouchableOpacity>
-          </Link>
+          <TouchableOpacity
+            onPress={() => {
+              bottomSheetRef.current?.close();
+              router.push('/(stack)/motivecreate');
+            }}
+          >
+            <Ionicons name="add" size={24} color={colors.text[1]} />
+          </TouchableOpacity>
         </LinearGradient>
       )}
 
@@ -160,19 +156,5 @@ const styles = StyleSheet.create({
     alignItems: "center",
     zIndex: 2000,
     backgroundColor: "rgba(0,0,0,0.15)",
-  },
-  friendsButton: {
-    position: "absolute",
-    bottom: spacing.xl,
-    left: spacing.xl,
-    backgroundColor: colors.bg[1],
-    padding: spacing.md,
-    borderRadius: 16,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-    elevation: 5,
-    zIndex: 1001,
   },
 });

--- a/HungerTracker/app/(tabs)/index.tsx
+++ b/HungerTracker/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { colors, spacing } from "../theme";
 import { Link, router } from "expo-router";
 import MotiveInvitation from "../components/MotiveInvitation";
 import { LinearGradient } from "expo-linear-gradient";
-import { BottomSheet } from "@gorhom/bottom-sheet";
+import BottomSheet, { BottomSheetMethods } from "@gorhom/bottom-sheet";
 import FriendsBottomSheet from "../components/FriendsBottomSheet";
 import type MapView from "react-native-maps";
 
@@ -14,7 +14,7 @@ export default function Index() {
   const [showInvite, setShowInvite] = useState(false);
   const [showMotiveButton, setShowMotiveButton] = useState(true);
   const mapRef = useRef<MapView>(null);
-  const bottomSheetRef = useRef<BottomSheet>(null);
+  const bottomSheetRef = useRef<BottomSheetMethods>(null);
 
   const handleFriendPress = (friend: MapUser) => {
     bottomSheetRef.current?.snapToIndex(0);

--- a/HungerTracker/app/(tabs)/index.tsx
+++ b/HungerTracker/app/(tabs)/index.tsx
@@ -7,6 +7,7 @@ import { Link, router } from "expo-router";
 import MotiveInvitation from "../components/MotiveInvitation";
 import { LinearGradient } from "expo-linear-gradient";
 import BottomSheet, { BottomSheetMethods } from "@gorhom/bottom-sheet";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import FriendsBottomSheet from "../components/FriendsBottomSheet";
 import type MapView from "react-native-maps";
 
@@ -15,6 +16,7 @@ export default function Index() {
   const [showMotiveButton, setShowMotiveButton] = useState(true);
   const mapRef = useRef<MapView>(null);
   const bottomSheetRef = useRef<BottomSheetMethods>(null);
+  const tabBarHeight = useBottomTabBarHeight();
 
   const handleFriendPress = (friend: MapUser) => {
     bottomSheetRef.current?.snapToIndex(0);
@@ -53,10 +55,13 @@ export default function Index() {
       </Link>
       {/* Motive Create Button */}
       {showMotiveButton && (
-        <LinearGradient colors={colors.grad.p1} style={styles.motiveButton}>
+        <LinearGradient
+          colors={colors.grad.p1}
+          style={[styles.motiveButton, { bottom: tabBarHeight + spacing.xl }]}
+        >
           <TouchableOpacity
             onPress={() => {
-              bottomSheetRef.current?.close();
+              bottomSheetRef.current?.snapToIndex(0);
               router.push('/(stack)/motivecreate');
             }}
           >

--- a/HungerTracker/app/components/Friend.tsx
+++ b/HungerTracker/app/components/Friend.tsx
@@ -11,10 +11,12 @@ export interface FriendData extends MapUser {
 interface Props {
   friend: FriendData;
   onPress?: () => void;
+  onInvite?: () => void;
 }
 
-export default function Friend({ friend, onPress }: Props) {
+export default function Friend({ friend, onPress, onInvite }: Props) {
   const handleInvite = () => {
+    onInvite?.();
     router.push('/(stack)/motivecreate');
   };
 

--- a/HungerTracker/app/components/Friend.tsx
+++ b/HungerTracker/app/components/Friend.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import { colors, spacing, fontSizes } from '../theme';
+import { router } from 'expo-router';
+import { MapUser } from './MapScreen';
+
+export interface FriendData extends MapUser {
+  subtitle: string;
+}
+
+interface Props {
+  friend: FriendData;
+  onPress?: () => void;
+}
+
+export default function Friend({ friend, onPress }: Props) {
+  const handleInvite = () => {
+    router.push('/(stack)/motivecreate');
+  };
+
+  return (
+    <TouchableOpacity style={styles.container} onPress={onPress} activeOpacity={0.8}>
+      <View style={styles.infoRow}>
+        <Image source={{ uri: friend.avatar }} style={styles.avatar} />
+        <View style={styles.textContainer}>
+          <Text style={styles.name}>{friend.name}</Text>
+          <Text style={styles.subtitle}>{friend.subtitle}</Text>
+        </View>
+      </View>
+      <TouchableOpacity style={styles.inviteButton} onPress={handleInvite}>
+        <Text style={styles.inviteText}>invite to motive</Text>
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.bg[2],
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    marginRight: spacing.md,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  name: {
+    color: colors.text[1],
+    fontSize: fontSizes.medium,
+    fontWeight: '600',
+  },
+  subtitle: {
+    color: colors.text[2],
+    fontSize: fontSizes.small,
+    marginTop: 2,
+  },
+  inviteButton: {
+    backgroundColor: colors.acc.p1,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: 20,
+  },
+  inviteText: {
+    color: colors.text[1],
+    fontSize: fontSizes.small,
+    fontWeight: '600',
+  },
+});

--- a/HungerTracker/app/components/FriendsBottomSheet.tsx
+++ b/HungerTracker/app/components/FriendsBottomSheet.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo, MutableRefObject } from 'react';
 import { View, Text, StyleSheet, FlatList } from 'react-native';
-import { BottomSheet, BottomSheetView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BottomSheet, { BottomSheetView, BottomSheetBackdrop, BottomSheetMethods } from '@gorhom/bottom-sheet';
 import { colors, spacing, fontSizes } from '../theme';
 import Friend, { FriendData } from './Friend';
 
 interface Props {
-  bottomSheetRef: MutableRefObject<BottomSheet | null>;
+  bottomSheetRef: MutableRefObject<BottomSheetMethods | null>;
   friends: FriendData[];
   onFriendPress: (friend: FriendData) => void;
   onChange?: (index: number) => void;

--- a/HungerTracker/app/components/FriendsBottomSheet.tsx
+++ b/HungerTracker/app/components/FriendsBottomSheet.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPress, onChange }: Props) {
-  const snapPoints = useMemo(() => ['25%', '60%', '90%'], []);
+  const snapPoints = useMemo(() => ['10%', '60%', '90%'], []);
 
   const handleSheetChanges = useCallback((index: number) => {
     onChange?.(index);
@@ -37,10 +37,9 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
       snapPoints={snapPoints}
       onChange={handleSheetChanges}
       backdropComponent={renderBackdrop}
-      enablePanDownToClose
       handleIndicatorStyle={styles.handle}
       backgroundStyle={styles.background}
-      bottomInset={70}
+      bottomInset={0}
       style={styles.sheet}
     >
       <BottomSheetView style={styles.container}>
@@ -52,7 +51,7 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
             <Friend
               friend={item}
               onPress={() => onFriendPress(item)}
-              onInvite={() => bottomSheetRef.current?.close()}
+              onInvite={() => bottomSheetRef.current?.snapToIndex(0)}
             />
           )}
           showsVerticalScrollIndicator={false}

--- a/HungerTracker/app/components/FriendsBottomSheet.tsx
+++ b/HungerTracker/app/components/FriendsBottomSheet.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPress, onChange }: Props) {
-  const snapPoints = useMemo(() => ['10%', '60%', '90%'], []);
+  const snapPoints = useMemo(() => ['10%', '60%', '80%'], []);
 
   const handleSheetChanges = useCallback((index: number) => {
     onChange?.(index);
@@ -53,10 +53,10 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.bg[1],
+    backgroundColor: colors.bg[2],
   },
   background: {
-    backgroundColor: colors.bg[1],
+    backgroundColor: colors.bg[2],
   },
   sheet: {
     zIndex: 1002,

--- a/HungerTracker/app/components/FriendsBottomSheet.tsx
+++ b/HungerTracker/app/components/FriendsBottomSheet.tsx
@@ -1,58 +1,80 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import Modal from 'react-native-modal';
-import { colors } from '../theme';
+import React, { useCallback, useMemo, MutableRefObject } from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import { BottomSheetModal, BottomSheetView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import { colors, spacing, fontSizes } from '../theme';
+import Friend, { FriendData } from './Friend';
 
 interface Props {
-  visible: boolean;
-  onClose: () => void;
+  bottomSheetRef: MutableRefObject<BottomSheetModal | null>;
+  friends: FriendData[];
+  onFriendPress: (friend: FriendData) => void;
+  onChange?: (index: number) => void;
 }
 
-export default function FriendsBottomSheet({ visible, onClose }: Props) {
+export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPress, onChange }: Props) {
+  const snapPoints = useMemo(() => ['25%', '60%', '90%'], []);
+
+  const handleSheetChanges = useCallback((index: number) => {
+    onChange?.(index);
+  }, [onChange]);
+
+  const renderBackdrop = useCallback(
+    (props: any) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        opacity={0.5}
+      />
+    ),
+    []
+  );
+
   return (
-    <Modal
-      isVisible={visible}
-      onBackdropPress={onClose}
-      swipeDirection="down"
-      onSwipeComplete={onClose}
-      style={styles.modal}
-      useNativeDriverForBackdrop
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      onChange={handleSheetChanges}
+      backdropComponent={renderBackdrop}
+      enablePanDownToClose
+      handleIndicatorStyle={styles.handle}
+      backgroundStyle={styles.background}
     >
-      <View style={styles.container}>
-        <View style={styles.handle} />
+      <BottomSheetView style={styles.container}>
         <Text style={styles.title}>Friends</Text>
-        <Text style={styles.subtitle}>This is a test bottom sheet</Text>
-      </View>
-    </Modal>
+        <FlatList
+          data={friends}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <Friend friend={item} onPress={() => onFriendPress(item)} />
+          )}
+          showsVerticalScrollIndicator={false}
+        />
+      </BottomSheetView>
+    </BottomSheetModal>
   );
 }
 
 const styles = StyleSheet.create({
-  modal: {
-    justifyContent: 'flex-end',
-    margin: 0,
-  },
   container: {
+    flex: 1,
     backgroundColor: colors.bg[1],
-    padding: 16,
-    borderTopLeftRadius: 16,
-    borderTopRightRadius: 16,
+  },
+  background: {
+    backgroundColor: colors.bg[1],
   },
   handle: {
     width: 40,
     height: 4,
-    borderRadius: 2,
     backgroundColor: colors.bg[3],
-    alignSelf: 'center',
-    marginBottom: 8,
+    borderRadius: 2,
   },
   title: {
-    fontSize: 24,
+    fontSize: fontSizes.large,
     color: colors.text[1],
-    marginBottom: 8,
-  },
-  subtitle: {
-    fontSize: 16,
-    color: colors.text[2],
+    fontWeight: '600',
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
   },
 });

--- a/HungerTracker/app/components/FriendsBottomSheet.tsx
+++ b/HungerTracker/app/components/FriendsBottomSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, MutableRefObject } from 'react';
-import { View, Text, StyleSheet, FlatList } from 'react-native';
-import BottomSheet, { BottomSheetView, BottomSheetBackdrop, BottomSheetMethods } from '@gorhom/bottom-sheet';
+import { Text, StyleSheet, FlatList } from 'react-native';
+import BottomSheet, { BottomSheetView, BottomSheetMethods } from '@gorhom/bottom-sheet';
 import { colors, spacing, fontSizes } from '../theme';
 import Friend, { FriendData } from './Friend';
 
@@ -18,17 +18,6 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
     onChange?.(index);
   }, [onChange]);
 
-  const renderBackdrop = useCallback(
-    (props: any) => (
-      <BottomSheetBackdrop
-        {...props}
-        disappearsOnIndex={-1}
-        appearsOnIndex={0}
-        opacity={0.5}
-      />
-    ),
-    []
-  );
 
   return (
     <BottomSheet
@@ -36,7 +25,7 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
       index={1}
       snapPoints={snapPoints}
       onChange={handleSheetChanges}
-      backdropComponent={renderBackdrop}
+      enablePanDownToClose={false}
       handleIndicatorStyle={styles.handle}
       backgroundStyle={styles.background}
       bottomInset={0}
@@ -70,8 +59,8 @@ const styles = StyleSheet.create({
     backgroundColor: colors.bg[1],
   },
   sheet: {
-    zIndex: 0,
-    elevation: 0,
+    zIndex: 1002,
+    elevation: 1002,
   },
   handle: {
     width: 40,

--- a/HungerTracker/app/components/FriendsBottomSheet.tsx
+++ b/HungerTracker/app/components/FriendsBottomSheet.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useMemo, MutableRefObject } from 'react';
 import { View, Text, StyleSheet, FlatList } from 'react-native';
-import { BottomSheetModal, BottomSheetView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import { BottomSheet, BottomSheetView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
 import { colors, spacing, fontSizes } from '../theme';
 import Friend, { FriendData } from './Friend';
 
 interface Props {
-  bottomSheetRef: MutableRefObject<BottomSheetModal | null>;
+  bottomSheetRef: MutableRefObject<BottomSheet | null>;
   friends: FriendData[];
   onFriendPress: (friend: FriendData) => void;
   onChange?: (index: number) => void;
@@ -31,15 +31,17 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
   );
 
   return (
-    <BottomSheetModal
+    <BottomSheet
       ref={bottomSheetRef}
-      index={0}
+      index={1}
       snapPoints={snapPoints}
       onChange={handleSheetChanges}
       backdropComponent={renderBackdrop}
       enablePanDownToClose
       handleIndicatorStyle={styles.handle}
       backgroundStyle={styles.background}
+      bottomInset={70}
+      style={styles.sheet}
     >
       <BottomSheetView style={styles.container}>
         <Text style={styles.title}>Friends</Text>
@@ -47,12 +49,16 @@ export default function FriendsBottomSheet({ bottomSheetRef, friends, onFriendPr
           data={friends}
           keyExtractor={(item) => item.id}
           renderItem={({ item }) => (
-            <Friend friend={item} onPress={() => onFriendPress(item)} />
+            <Friend
+              friend={item}
+              onPress={() => onFriendPress(item)}
+              onInvite={() => bottomSheetRef.current?.close()}
+            />
           )}
           showsVerticalScrollIndicator={false}
         />
       </BottomSheetView>
-    </BottomSheetModal>
+    </BottomSheet>
   );
 }
 
@@ -63,6 +69,10 @@ const styles = StyleSheet.create({
   },
   background: {
     backgroundColor: colors.bg[1],
+  },
+  sheet: {
+    zIndex: 0,
+    elevation: 0,
   },
   handle: {
     width: 40,

--- a/HungerTracker/app/components/MapScreen.tsx
+++ b/HungerTracker/app/components/MapScreen.tsx
@@ -27,7 +27,7 @@ export const EXAMPLE_USERS: MapUser[] = [
       latitude: 43.4643,
       longitude: -80.5204,
     },
-    avatar: "https://i.pravatar.cc/150?img=1",
+    avatar: "https://i.pravatar.cc/150?img",
   },
   {
     id: "2",
@@ -36,7 +36,7 @@ export const EXAMPLE_USERS: MapUser[] = [
       latitude: 43.4675,
       longitude: -79.6877,
     },
-    avatar: "https://i.pravatar.cc/150?img=5",
+    avatar: "https://i.pravatar.cc/150?img",
   },
   {
     id: "3",
@@ -45,7 +45,7 @@ export const EXAMPLE_USERS: MapUser[] = [
       latitude: 43.46843,
       longitude: -79.74241,
     },
-    avatar: "https://i.pravatar.cc/150?img=3",
+    avatar: "https://i.pravatar.cc/150?img",
   },
 ];
 

--- a/HungerTracker/app/components/MapScreen.tsx
+++ b/HungerTracker/app/components/MapScreen.tsx
@@ -8,8 +8,18 @@ type LocationCoords = {
   longitude: number;
 } | null;
 
+export type MapUser = {
+  id: string;
+  name: string;
+  location: {
+    latitude: number;
+    longitude: number;
+  };
+  avatar: string;
+};
+
 // Example user data - in a real app, this would come from your backend
-const EXAMPLE_USERS = [
+export const EXAMPLE_USERS: MapUser[] = [
   {
     id: "1",
     name: "Laughter",
@@ -46,7 +56,7 @@ const DEFAULT_REGION: Region = {
   longitudeDelta: 0.0421,
 };
 
-export default function MapScreen() {
+export default function MapScreen({ mapRef }: { mapRef: React.RefObject<MapView> }) {
   const [location, setLocation] = useState<LocationCoords>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -104,6 +114,7 @@ export default function MapScreen() {
   return (
     <View style={styles.container}>
       <MapView
+        ref={mapRef}
         style={styles.map}
         region={region}
         onRegionChangeComplete={setRegion}


### PR DESCRIPTION
## Summary
- add `Friend` list item component
- rebuild `FriendsBottomSheet` using gorhom bottom sheet
- expose `EXAMPLE_USERS` and map ref in `MapScreen`
- show FriendsBottomSheet in `(tabs)/index` with logic to hide the motive create button when sheet is expanded

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d70646c883269fc4480d3e44ae73